### PR TITLE
RG-6: Refactor output as `iframe`

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             </div>
 
             <!-- Errors -->
-            <div id='errors' class='alert alert-danger' role='alert'>
+            <div id='errors' class='alert alert-danger hide' role='alert'>
                 <ul id='error-list' class='list-unstyled'></ul>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -15,40 +15,35 @@
         <link rel='stylesheet' href='./style.css' />
     </head>
     <body>
-        <!-- Instructions -->
-        <div id='instructions' class='panel panel-info'>
-            <div class='panel-heading'>
-                <h3 class='panel-title'>Instructions</h3>
+        <!-- Main -->
+        <div id='main'>
+            <!-- Instructions -->
+            <div id='instructions' class='panel panel-info'>
+                <div class='panel-heading'>
+                    <h3 class='panel-title'>Instructions</h3>
+                </div>
+                <div class='panel-body'>
+                    Below we have a blank component. Inside of the <code>render</code> method we want to return a <code>&lt;div&gt;</code> with the text <code>Hello World!</code>.
+                </div>
             </div>
-            <div class='panel-body'>
-                Below we have a blank component. Inside of the <code>render</code> method we want to return a <code>&lt;div&gt;</code> with the text <code>Hello World!</code>.
+
+            <!-- Errors -->
+            <div id='errors' class='alert alert-danger' role='alert'>
+                <ul id='error-list' class='list-unstyled'></ul>
             </div>
-        </div>
 
-        <!-- Errors -->
-        <div id='errors' class='alert alert-danger' role='alert'>
-            <ul id='error-list' class='list-unstyled'></ul>
-        </div>
-
-        <!-- Container -->
-        <div class='content'>
             <!-- Editor -->
             <div id='editor'></div>
+
             <!-- Output -->
-            <div id='output'></div>
-        </div>
+            <iframe id='output' frameborder='0'></iframe>
+        </div><!-- / #main -->
 
         <!-- Overlay -->
         <div id='overlay'>
             <i class='fa fa-circle-o-notch fa-spin fa-5x'></i>
         </div>
 
-        <!-- Babel Transpiler -->
-        <script src='//cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js'></script>
-        <!-- React -->
-        <script src='//cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react.js'></script>
-        <!-- ReactDOM -->
-        <script src='//cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js'></script>
         <!-- Ace Editor -->
         <script src='//cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js'></script>
         <!-- Lodash -->

--- a/main.js
+++ b/main.js
@@ -74,9 +74,11 @@
     editor.setTheme('ace/theme/monokai');
     session.setMode('ace/mode/jsx');
 
-    // code
+    // todo: get code from JSON
     var code = (
-        'var Component = React.createClass({\n\trender: function() {\n\t\treturn;\n\t}\n});'
+        'var Component = React.createClass({\n\t' +
+        'render: function() {\n\t\treturn;\n\t}\n});' +
+        '\n\nReactDOM.render(<Component />, document.body);'
     );
 
     editor.insert(code);
@@ -153,8 +155,7 @@
     function renderOutput(editorValue, outputNode, errorListNode) {
         try {
             // todo: use test case from JSON
-            var renderComponentCode = 'ReactDOM.render(React.createElement(Component), document.body)';
-            var transpiledCode = iframeWindow.babel.transform(editorValue + renderComponentCode).code;
+            var transpiledCode = iframeWindow.babel.transform(editorValue).code;
 
             // run the transpiled code
             iframeWindow.eval(transpiledCode);

--- a/main.js
+++ b/main.js
@@ -27,9 +27,16 @@
 
         // construct iframe document
         iframeDocument.open();
+        var url, extension;
         var html = ['<head>'];
         for (var i = 0, l = dependencies.length; i < l; i++) {
-            html.push('<script src="' + dependencies[i] + '"></script>');
+            url = dependencies[i];
+            extension = url.split('.').pop().toLowerCase();
+            if (extension === 'js') {
+                html.push('<script src="' + url + '"></script>');
+            } else if (extension === 'css') {
+                html.push('<link rel="stylesheet" href="' + url + '" />');
+            }
         }
         html.push('</head>');
         iframeDocument.write(html.join(''));

--- a/main.js
+++ b/main.js
@@ -4,30 +4,55 @@
     // cache DOM elements
     var errorListNode = document.getElementById('error-list');
     var outputNode;
-    var iframe = document.getElementById('output');
-    var iframeWindow = iframe.contentWindow;
-    window.iframeWindow = iframeWindow;
-    var iframeDocument = iframeWindow ? iframe.contentWindow.document : iframe.contentDocument;
 
-    // build iframe
-    iframeDocument.open();
+    /**
+     * Initializes iframe window and document for level output.
+     *
+     * @param {DOMElement} node - The DOM node, which can be an iframe.
+     * @param {Array} dependencies - The script dependencies for the iframe head.
+     * @return {Window} - The iframe window object.
+     */
+    function initializeIframe(node, dependencies) {
+        var iframe = node;
+
+        // use iframe node or create and append an iframe into node
+        if (iframe.nodeName !== 'IFRAME') {
+            iframe = document.createElement('iframe');
+            node.appendChild(iframe);
+        }
+
+        // get iframe window and document
+        var iframeWindow = iframe.contentWindow || iframe;
+        var iframeDocument = iframe.contentDocument || iframe.contentWindow.document;
+
+        // construct iframe document
+        iframeDocument.open();
+        var html = ['<head>'];
+        for (var i = 0, l = dependencies.length; i < l; i++) {
+            html.push('<script src="' + dependencies[i] + '"></script>');
+        }
+        html.push('</head>');
+        iframeDocument.write(html.join(''));
+        iframeDocument.close();
+
+        return iframeWindow;
+    }
+
     // todo: get script dependencies from JSON
     var dependencies = [
         '//cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.js',
         '//cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react.js',
         '//cdnjs.cloudflare.com/ajax/libs/react/0.14.6/react-dom.js'
     ];
-    var html = '<html><head>';
-    for (var dep in dependencies) {
-        html += '<script src="' + dependencies[dep] + '"></script>';
-    }
-    html += '</head><body></body></html>';
-    iframeDocument.write(html);
-    iframeDocument.close();
+
+    var iframeWindow = initializeIframe(
+        document.getElementById('output'),
+        dependencies
+    );
 
     // iframe onload
     iframeWindow.onload = function() {
-        outputNode = iframeDocument.body;
+        outputNode = iframeWindow.document.body;
         renderOutput(editor.getValue(), outputNode, errorListNode);
     };
 

--- a/main.js
+++ b/main.js
@@ -71,10 +71,10 @@
     });
 
     // refresh on change
-    editor.on('change', function() {
-        // todo: get expected output from JSON
-        onEditorChange(editor.getValue(), 'Hello World!', outputNode, errorListNode);
-    });
+    // todo: get expected output from JSON
+    editor.on('change', window._.debounce(function() {
+         onEditorChange(editor.getValue(), 'Hello World!', outputNode, errorListNode);
+    }, 500));
 
     /**
      * Refreshes Ace editor on change.

--- a/style.css
+++ b/style.css
@@ -1,7 +1,35 @@
+/* general */
 html, body {
     height: 100%;
 }
 
+#instructions,
+#errors {
+    margin-bottom: 0;
+}
+
+/* ace editor and output */
+#editor,
+#output {
+    position: absolute;
+    width: 50%;
+    height: 100%;
+    padding: 0;
+    overflow:scroll;
+}
+
+#output {
+    background-color: #fafafa;
+    right: 0;
+}
+
+.editable-highlight {
+    background-color: #666;
+    opacity: 0.5;
+    position: absolute;
+}
+
+/* modal overlay */
 #overlay {
     background: #000;
     opacity: 0.5;
@@ -27,34 +55,4 @@ html, body {
 .js #overlay,
 .js #overlay > .fa-circle-o-notch {
     display: none;
-}
-
-#instructions,
-#errors {
-    margin-bottom: 0;
-}
-
-.editable-highlight {
-    background-color: #666;
-    opacity: 0.5;
-    position: absolute;
-}
-
-.content {
-    position: relative;
-    height: 100%;
-}
-
-#editor,
-#output {
-    position: absolute;
-    width: 50%;
-    height: 100%;
-    padding: 0;
-    overflow:scroll;
-}
-
-#output {
-    background-color: #fafafa;
-    right: 0;
 }


### PR DESCRIPTION
Resolve #6
- Use `iframe` as the output element in order to decouple page from level (prevent potential script conflicts)
- Update scripts to work with `iframe`
- Refactor current example so that the code inside the editor can run by itself
- Use debounce on editor change event listener so error messages update less frequently
- Hide error messages when page first loads
